### PR TITLE
[fix] 修正

### DIFF
--- a/my-app/app/auth/forgot-password/page.tsx
+++ b/my-app/app/auth/forgot-password/page.tsx
@@ -112,7 +112,9 @@ export default function ForgotPasswordPage() {
           <img 
             src="/images/meguru_logo.png" 
             alt="meguru" 
-            className="h-12 mx-auto"
+            className="mx-auto"
+            width={254}
+            height={70}
           />
         </div>
 

--- a/my-app/app/auth/login/page.tsx
+++ b/my-app/app/auth/login/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import Image from "next/image"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
@@ -66,7 +67,9 @@ const handleLogin = async () => {
           <img 
             src="/images/meguru_logo.png" 
             alt="meguru" 
-            className="h-12 mx-auto"
+            className="mx-auto"
+            width={254}
+            height={70}
           />
         </div>
 
@@ -102,7 +105,8 @@ const handleLogin = async () => {
           </div>
 
           <div className="text-left">
-            <Link href="/auth/forgot-password" className="text-sm text-gray-500 hover:text-gray-700">
+            <Link href="/auth/forgot-password" className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-3">
+            <Image src="/images/Vector 35.svg" alt="meguru" width={6} height={9} />
               パスワードを忘れた方
             </Link>
           </div>
@@ -115,7 +119,7 @@ const handleLogin = async () => {
 
           <Button
             onClick={handleLogin}
-            className="w-full h-12 text-white font-medium rounded-lg hover:opacity-90 transition-all"
+            className="w-full h-12 text-white font-medium rounded-full hover:opacity-90 transition-all"
             style={{ backgroundColor: '#F1B300' }}
           >
             ログインする
@@ -124,7 +128,7 @@ const handleLogin = async () => {
           <Button
             variant="outline"
             asChild
-            className="w-full h-12 font-medium rounded-lg border-2 hover:bg-gray-50 transition-all"
+            className="w-full h-12 font-medium rounded-full border-2 hover:bg-gray-50 transition-all"
             style={{ borderColor: '#F1B300', color: '#F1B300' }}
           >
             <Link href="/auth/register">新規登録</Link>

--- a/my-app/app/auth/register/page.tsx
+++ b/my-app/app/auth/register/page.tsx
@@ -175,7 +175,9 @@ export default function RegisterPage() {
           <img 
             src="/images/meguru_logo.png" 
             alt="meguru" 
-            className="h-12 mx-auto"
+            className="mx-auto"
+            width={254}
+            height={70}
           />
         </div>
 
@@ -222,7 +224,7 @@ export default function RegisterPage() {
 
             <Button
               onClick={handleStep1Submit}
-              className="w-full h-12 text-white font-medium rounded-lg hover:opacity-90 transition-all"
+              className="w-full h-12 text-white font-medium rounded-full hover:opacity-90 transition-all"
               style={{ backgroundColor: '#F1B300' }}
             >
               送信する
@@ -265,7 +267,7 @@ export default function RegisterPage() {
 
             <Button
               onClick={handleStep2Submit}
-              className="w-full h-12 text-white font-medium rounded-lg hover:opacity-90 transition-all"
+              className="w-full h-12 text-white font-medium rounded-full hover:opacity-90 transition-all"
               style={{ backgroundColor: '#F1B300' }}
             >
               送信する
@@ -277,20 +279,20 @@ export default function RegisterPage() {
         {step === 3 && (
           <div className="space-y-8 text-center">
             <div className="space-y-4">
-              <h2 className="text-xl text-gray-900">
-                新規会員登録が<br />完了しました
-              </h2>
-              <p className="text-sm text-gray-600">
+            <div className="self-stretch h-20 mt-[70px] text-center justify-start text-zinc-800 text-2xl font-normal font-['Noto_Sans_JP']">
+              新規会員登録が<br/>完了しました
+            </div>
+              <p className="text-sm text-gray-600 mt-[14px] mb-[88px]">
                 ホームに戻り献立レシピを作りましょう
               </p>
             </div>
 
             <Button
               onClick={handleCompleteRegistration}
-              className="w-full h-12 text-white font-medium rounded-lg hover:opacity-90 transition-all"
+              className="w-full h-12 text-white font-medium rounded-full hover:opacity-90 transition-all"
               style={{ backgroundColor: '#F1B300' }}
             >
-              レシピを作る
+              レシピを探す
             </Button>
           </div>
         )}

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Link from "next/link"
+// import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
@@ -43,7 +43,7 @@ export default function Home() {
               <Button 
                 className="w-full text-white text-lg py-6 rounded-lg hover:opacity-90 transition-all"
                 style={{ backgroundColor: '#F1B300' }}
-                onClick={() => window.open('https://www.meguru-food.jp/', '_blank')}
+                onClick={() => window.open('https://www.meguru-food.jp/auth/login', '_blank')}
               >
                 ログインして始める
               </Button>

--- a/my-app/public/images/Vector 35.svg
+++ b/my-app/public/images/Vector 35.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 9.5V0.5L6 5L0 9.5Z" fill="#F1B300"/>
+</svg>


### PR DESCRIPTION
▼ログイン画面

; 「パスワード忘れた人」の左にある、▶を追加する（figma参照）

; ボタンの形を、Figmaの通り変更する


▼新規アカウント登録

; ロゴのサイズを変更する（Figma参照）

; ボタンの形を、Figmaの通り変更する


▼アカウント登録画面

; 「新規会員登録が完了しました」のフォントサイズを、Figmaの通りに変更する

; 「新規会員登録が完了しました」と「ホームに戻り献立レシピを作りましょう」との行間を調整する

; ●テキスト変更「レシピを作る」→「レシピを探す」

; 「レシピを作る」ボタンを丸ボタンにする
