### PR TITLE
フレーム統一

### DIFF
--- a/my-app/components/Recipes/RecipeDetail/RecipeImage.tsx
+++ b/my-app/components/Recipes/RecipeDetail/RecipeImage.tsx
@@ -21,7 +21,7 @@ export default function RecipeImage({ image }: RecipeImageProps) {
       </Link>
       </div>
       <Image
-        className="w-full h-96 object-cover"
+        className="w-[390px] h-96 object-cover"
         src={image}
         alt="レシピ画像"
         width={1000}

--- a/my-app/components/Recipes/RecipeItem.tsx
+++ b/my-app/components/Recipes/RecipeItem.tsx
@@ -13,7 +13,7 @@ export default function RecipeItem({ recipe }: RecipeItemProps) {
     <>
       <Link href={`/user/recipes/${recipe.recipe_id}`}>
         <div className="self-stretch py-[16px] flex flex-col justify-start items-start">
-          <div className="self-stretch rounded-xl inline-flex items-start gap-x-6">
+          <div className="self-stretch rounded-xl inline-flex items-start ml-[16px]">
             <div className="w-[120px] h-[120px] relative rounded-xl overflow-hidden">
               {recipe.image_url && (
                 <Image
@@ -43,7 +43,7 @@ export default function RecipeItem({ recipe }: RecipeItemProps) {
               </div>
             </div>
             <div className="w-56 inline-flex flex-col justify-start items-start gap-4">
-              <div className="self-stretch flex flex-col justify-start items-start gap-1">
+              <div className="self-stretch flex flex-col justify-start items-start ml-[16px]">
                 <div className="self-stretch flex flex-col justify-start items-start">
                   <div className="self-stretch justify-start text-slate-500 text-sm font-normal font-['Noto_Sans_JP'] leading-tight">
                     調理時間 {recipe.cook_time}分　{recipe.calories}kcal　{recipe.total_price}円

--- a/my-app/components/Recipes/store-recipes/store-recipe-header.tsx
+++ b/my-app/components/Recipes/store-recipes/store-recipe-header.tsx
@@ -36,13 +36,13 @@ export default function StoreRecipesHeader({ recipe, setFilteredRecipes }: Store
 
     return (
         <div className="bg-stone-100">
-            <div className="self-stretch px-4 py-2 bg-stone-100 inline-flex justify-between items-center">
+            <div className="self-stretch px-[16px] py-[8px] w-[390px] bg-stone-100 inline-flex justify-between items-center">
                 <div className="w-96 relative flex justify-between items-center">
                     <div className="w-6 h-6 relative"></div>
                     <div className="h-6 p-2 bg-white rounded flex justify-end items-center gap-1">
                         <StoreRecipeSelect setSortOrder={setSortOrder}/>
                     </div>
-                    <div className="left-[160px] top-[0.50px] absolute text-center justify-start text-neutral-900 text-sm font-bold font-['Noto_Sans_JP'] leading-snug">保存リスト</div>
+                    <div className="absolute left-1/2 -translate-x-1/2 text-center justify-start text-neutral-900 text-sm font-bold font-['Noto_Sans_JP'] leading-snug">保存リスト</div>
                 </div>
             </div>
             <div className="w-full h-10 relative bg-stone-100 flex justify-center items-center">

--- a/my-app/components/Recipes/store-recipes/store-recipe-item.tsx
+++ b/my-app/components/Recipes/store-recipes/store-recipe-item.tsx
@@ -7,8 +7,8 @@ export default function StoreRecipeItem({ recipe }: { recipe: Recipe }) {
     <>
       <Link href={`/user/recipes/${recipe.recipe_id}`}>
         <div className="self-stretch py-[16px] flex flex-col justify-start items-start">
-          <div className="self-stretch rounded-xl inline-flex items-start gap-x-6">
-            <div className="w-[120px] h-[120px] relative rounded-xl overflow-hidden">
+          <div className="self-stretch rounded-xl inline-flex items-start">
+            <div className="w-[120px] h-[120px] ml-[16px] relative rounded-xl overflow-hidden">
               {recipe.image_url && (
                 <Image
                   src={recipe.image_url}
@@ -19,7 +19,7 @@ export default function StoreRecipeItem({ recipe }: { recipe: Recipe }) {
               )}
             </div>
             <div className="w-56 inline-flex flex-col justify-start items-start gap-4">
-              <div className="self-stretch flex flex-col justify-start items-start gap-1">
+              <div className="self-stretch flex flex-col justify-start items-start ml-[16px]">
                 <div className="self-stretch flex flex-col justify-start items-start">
                   <div className="self-stretch justify-start text-slate-500 text-sm font-normal font-['Noto_Sans_JP'] leading-tight">
                     調理時間 {recipe.cook_time}分　{recipe.calories}kcal

--- a/my-app/components/Recipes/user-header.tsx
+++ b/my-app/components/Recipes/user-header.tsx
@@ -19,7 +19,7 @@ export default function UserHeader({ onCategoryChange }: UserHeaderProps) {
   const [selectedCategory, setSelectedCategory] = useState('ai_recommended_recipes');
   return (
     <>
-      <div className="self-stretch py-2 bg-stone-100 inline-flex justify-between items-center">
+      <div className="self-stretch py-[8px] px-[16px] w-[390px] bg-stone-100 inline-flex justify-between items-center">
           <div className="w-full relative flex justify-between items-center">
               <div className="w-6 h-6 relative overflow-hidden">
                 {/* カメラに戻る */}

--- a/my-app/components/navbar.tsx
+++ b/my-app/components/navbar.tsx
@@ -37,7 +37,7 @@ export default function Navbar() {
   }
 
   return (
-    <nav className="fixed left-0 right-0 bottom-0 w-[440px] mx-auto bg-stone-100 border-t z-50">
+    <nav className="fixed left-0 right-0 bottom-0 w-[390px] mx-auto bg-stone-100 border-t z-50">
       <div className="flex justify-around items-center h-16">
         <Link
           href="/user"


### PR DESCRIPTION
ナビゲーションバーとレシピ関連コンポーネントのデザインを調整し、幅を390pxに統一しました。また、レシピ詳細画像のサイズを修正し、ストア…レシピアイテムのマージンを調整しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized layout width to 390px across navbar, headers, and recipe images for consistency.
  - Adjusted padding and margins (8px vertical, 16px horizontal) to improve alignment and spacing.
  - Centered the “保存リスト” label in the stored recipes header for better readability.
  - Reduced horizontal gaps in recipe items to create a cleaner, more compact presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->